### PR TITLE
Feat/issue 22

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,6 +5,7 @@ import { removeEncryptStorage, setEncryptStorage } from "../utils/encryptStorage
 import { removeHeader, setHeader } from "../utils/header";
 import { useEffect } from "react";
 import queryClient from '../api/queryClient';
+import { useNavigation } from "@react-navigation/native";
 
 
 
@@ -59,18 +60,24 @@ function useGetRefreshToken(){
 }
 
 function useLogout(mutationOptions?: UseMutationCustomOptions){
+    const navigation = useNavigation();
+
     return useMutation({
         mutationFn: logout,
         onSuccess:()=>{
             removeHeader('Authorization');
             removeEncryptStorage('refreshToken');
+            
+            navigation.reset({
+                index: 0,
+                routes: [{ name: 'Login' }],
+            });
         },
         onSettled:()=>{
             queryClient.invalidateQueries({queryKey:['auth']})
         },
         ...mutationOptions
     });
-
 }
 
 function useAuth(){

--- a/src/screens/club/ClubListScreen.tsx
+++ b/src/screens/club/ClubListScreen.tsx
@@ -51,9 +51,9 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
   return (
     <View style={styles.container}>
       <View style={styles.headerContainer}>
-        <Text style={styles.userName}>
+        {/* <Text style={styles.userName}>
           백진암
-        </Text>
+        </Text> */}
         <Icon
           name="alert"
           style={styles.alerIcon}
@@ -149,12 +149,11 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: 'black',
   },
-  logoutIcon: {
+  alerIcon:{
     fontSize: 30,
     color: 'rgba(153, 102, 255, 1)',
   },
-  alerIcon:{
-    marginLeft: 210,
+  logoutIcon: {
     fontSize: 30,
     color: 'rgba(153, 102, 255, 1)',
   },


### PR DESCRIPTION
- 모임 리스트 스크린에서 모임 리스트가 조회되지 않는 문제
**예상되는 원인 중 하나**
테스트 과정에서 중복 로그인이 발생 -> 서버에서는 중복 로그인 처리 x -> 특정 사용자에 대한 모임 조회 실패 -> 모임 조회시 토큰으로부터 사용자 정보를 조회하지만 토큰 검증 과정에서 중복 로그인으로 인해 검증 실패 -> 모임 리스트 조회 실패
**해결**
현재로서는 서버에서 중복 로그인을 처리하는 기능이 없기 때문에 상기한 원인에 대한 해결책은 제시 불가능.
하지만 다른 원인으로 인해 모임 리스트 조회 일시적으로 동작하지 않았을 때, 사용자가 직접 새로 고침할 수 있도록 구현
React Native의 RefreshControl를 이용해서 구현

- A 사용자가 로그아웃 하고 B 사용자로 로그인 했을 때, A사용자의 모임 리스트가 조회되는 문제
**원인**
로그아웃 시, 네비게이션 스택이 초기화 되지 않음 -> 새로운 사용자가 로그인 하고 모임 리스트 조회 스크린 이동 시, 기존 스택에서 스크린을 꺼내오는듯? -> 결과적으로 useQuery동작 x -> 이전 사용자의 모임 리스트가 조회됨
**해결**
로그아웃 useMutation에서 로그아웃 성공 시, 스택을 초기화하도록 구현
