### PR TITLE
[feat] issue-#24: 웹뷰 통신 완료

### DIFF
--- a/src/screens/webview/WebViewScreen.tsx
+++ b/src/screens/webview/WebViewScreen.tsx
@@ -1,12 +1,36 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useEffect, useRef, useState } from 'react';
 import { BackHandler, Dimensions, SafeAreaView, StyleSheet } from 'react-native';
-import WebView from 'react-native-webview';
+import WebView, { WebViewMessageEvent } from 'react-native-webview';
 import { mainNavigations } from '../../constants/navigations';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 
 const windowWidth = Dimensions.get('window').width;
 const windowHeight = Dimensions.get('window').height;
+const injectedJavascript = `
+      (function() {
+        function wrap(fn) {
+          return function wrapper() {
+            var res = fn.apply(this, arguments);
+  
+            window.ReactNativeWebView.postMessage(JSON.stringify({
+              type: 'navigationStateChange'
+            }));
+            return res;
+          }
+        }
+  
+        history.pushState = wrap(history.pushState);
+        history.replaceState = wrap(history.replaceState);
+        window.addEventListener('popstate', function() {
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'navigationStateChange'
+          }));
+        });
+      })();
+  
+      true;
+    `
 
 type WebViewScreenProps = StackScreenProps<
   MainStackParamList,
@@ -15,19 +39,35 @@ type WebViewScreenProps = StackScreenProps<
 
 function WebViewScreen({ route, navigation }: WebViewScreenProps) {
   const { clubId } = route.params;
-  const [receivedData, setReceivedData] = useState('');
   const webViewRef = useRef<WebView>(null);
   const [isCanGoBack, setIsCanGoBack] = useState(false);
-
   const onPressHardwareBackButton = () => {
     if (webViewRef.current && isCanGoBack) {
       webViewRef.current.goBack();
       return true;
-    } 
+    }
     else {
       return false;
     }
   };
+  const onMessage = ({ nativeEvent: e }: WebViewMessageEvent) => {
+    const data = JSON.parse(e.data);
+    if (data.type === 'navigationStateChange') {
+      setIsCanGoBack(e.canGoBack);
+    } else if (data.type === 'eventCreate') {
+      navigation.navigate(mainNavigations.EVENT_CREATE, { clubId: data.clubId });
+    } else if (data.type === 'eventConfig') {
+      
+    }
+  };
+  const onLoad = () => {
+    if (webViewRef.current) {
+      webViewRef.current.injectJavaScript(injectedJavascript);
+      webViewRef.current.postMessage(JSON.stringify({
+        isChongmu: true,
+      }));
+    }
+  }
 
   useEffect(() => {
     BackHandler.addEventListener('hardwareBackPress', onPressHardwareBackButton);
@@ -36,52 +76,19 @@ function WebViewScreen({ route, navigation }: WebViewScreenProps) {
     }
   }, [isCanGoBack]);
 
-  useEffect(() => {
-    if (webViewRef.current && receivedData) {
-      console.log('React로 보낼 데이터: ', receivedData);
-      webViewRef.current.postMessage(receivedData);
-      navigation.navigate(mainNavigations.EVENT_CREATE, { clubId: clubId });
-    }
-  }, [receivedData, webViewRef.current]);
-
   return (
     <SafeAreaView style={styles.container}>
       <WebView
         ref={webViewRef}
-        // source={{ uri: `https://movis.klr.kr/clubs/${clubId}` }}
-        source={{ uri: `https://movis.klr.kr` }}
-        onMessage={({ nativeEvent: state }) => {
-          if (state.data === 'navigationStateChange') {
-            setIsCanGoBack(state.canGoBack);
-            return;
-          }
-          setReceivedData(state.data);
-        }}
-        onLoadStart={() => webViewRef.current.injectJavaScript(`
-          (function() {
-            function wrap(fn) {
-              return function wrapper() {
-                var res = fn.apply(this, arguments);
-                window.ReactNativeWebView.postMessage('navigationStateChange');
-                return res;
-              }
-            }
-      
-            history.pushState = wrap(history.pushState);
-            history.replaceState = wrap(history.replaceState);
-            window.addEventListener('popstate', function() {
-              window.ReactNativeWebView.postMessage('navigationStateChange');
-            });
-          })();
-      
-          true;
-        `)}
+        source={{ uri: `https://movis.klr.kr/clubs/${clubId}` }}
+        // source={{ uri: `http://10.0.2.2:3000/` }}
+        onMessage={onMessage}
+        onLoad={onLoad}
         style={styles.webview}
       />
     </SafeAreaView>
   );
 };
-
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
- react <-> react native 통신 데이터 설정
기존 문자열 방식에서 json형식으로 통신하도록
다만, 전송할 때는 객체형식이 아니라 문자열형식으로 해야함
- react native -> react 통신 성공
기존에는 앱->웹으로의  통신이 안되었음
로컬에서 테스트 결과, 웹에서의 수신 방식에 문제
android에서 webView로 접근하는 경우 window가 아니라 document를 통해 eventListener를 등록해야함
   

