### PR TITLE
[feat] issue-#36: API연결 완료

### DIFF
--- a/src/api/eventBill.ts
+++ b/src/api/eventBill.ts
@@ -1,0 +1,18 @@
+import { EventBillCreateReq } from "../types/eventBill/request/EventBillCreateReq";
+import axiosHost from "./axios";
+
+type EventBillCreateReqWithParams = {
+  body: EventBillCreateReq;
+  queryParams?: Record<string, any>;
+};
+
+const createEvenBill = async ({ body, queryParams }: EventBillCreateReqWithParams): Promise<void> => {
+  const config = {
+    params: queryParams,
+  };
+  const { data } = await axiosHost.post('/api/v1/eventBill/input', body, config);
+
+  return data;
+};
+
+export { createEvenBill };

--- a/src/api/eventMember.ts
+++ b/src/api/eventMember.ts
@@ -1,0 +1,15 @@
+import { ClubGetListRes } from "../types/club/response/ClubGetListRes";
+import { EventMemberGetListRes } from "../types/eventMember/response/EventMemberGetListRes";
+import axiosHost from "./axios";
+
+const getEventMemberList = async (queryParams: Record<string, any>): Promise<EventMemberGetListRes> => {
+	const config = {
+		params: queryParams,
+	};
+  const { data } = await axiosHost.get('/api/v1/eventMembers', config);
+
+  return data;
+};
+
+
+export { getEventMemberList };

--- a/src/api/fee.ts
+++ b/src/api/fee.ts
@@ -1,0 +1,18 @@
+import { FeeCreateReq } from "../types/fee/request/feeCreateReq";
+import axiosHost from "./axios";
+
+type FeeCreateReqWithParams = {
+  body: FeeCreateReq;
+  queryParams?: Record<string, any>;
+};
+
+const createFee = async ({body, queryParams }: FeeCreateReqWithParams): Promise<void> => {
+  const config = {
+    params: queryParams,
+  };
+  const { data } = await axiosHost.post('/api/v1/fees/input', body, config);
+
+  return data;
+};
+
+export { createFee }

--- a/src/components/DateTimePickerWithAntDInput.tsx
+++ b/src/components/DateTimePickerWithAntDInput.tsx
@@ -55,7 +55,6 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   inputWrapper: {
-    backgroundColor: 'red',
     justifyContent: 'center',
     height: '100%',
   },

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -5,6 +5,9 @@ const queryKeys = {
   
   MEMBER: 'member',
   GET_MEMBERLIST: 'getMemberList',
+
+  EVENT_MEMBER: 'eventMember',
+  GET_EVENT_MEMBERLIST: 'getEventMemberList',
 } as const;
 
 const storageKeys = {

--- a/src/hooks/useEventBill.ts
+++ b/src/hooks/useEventBill.ts
@@ -1,0 +1,15 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { createEvenBill } from "../api/eventBill";
+import { UseMutationCustomOptions } from "../types/common";
+
+function useMutateCreateEventBill(
+  mutationOptions?: UseMutationCustomOptions
+) {
+  return useMutation({
+    mutationFn: createEvenBill,
+    ...mutationOptions
+  })
+}
+
+export { useMutateCreateEventBill };

--- a/src/hooks/useEventMember.ts
+++ b/src/hooks/useEventMember.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "../constants/key";
+import { getEventMemberList } from "../api/eventMember";
+
+
+function useGetEventMemberList(eventId: string) {
+  return useQuery({
+    queryFn: () => getEventMemberList({eventId}),
+    queryKey: [queryKeys.EVENT_MEMBER, queryKeys.GET_EVENT_MEMBERLIST]
+  })
+}
+
+export { useGetEventMemberList };

--- a/src/hooks/useFee.ts
+++ b/src/hooks/useFee.ts
@@ -1,0 +1,15 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { createFee } from "../api/fee";
+import { UseMutationCustomOptions } from "../types/common";
+
+function useMutateCreateFee(
+  mutationOptions?: UseMutationCustomOptions
+) {
+  return useMutation({
+    mutationFn: createFee,
+    ...mutationOptions
+  })
+}
+
+export { useMutateCreateFee };

--- a/src/screens/club/ClubDetailScreen.tsx
+++ b/src/screens/club/ClubDetailScreen.tsx
@@ -127,10 +127,10 @@ const ClubDetailScreen = ({ route, navigation }: ClubDetailScreenProps) => {
               계좌번호(뒤 4자리){club.accountNumber}
             </Text>
           </View>
-          {/* <AntdWithStyleButton onPress={() => navigation.navigate(mainNavigations.EVENT_CREATE, { clubId: club.clubId })}>
+          <AntdWithStyleButton onPress={() => navigation.navigate(mainNavigations.EVENT_CREATE, { clubId: club.clubId })}>
             이벤트 생성(테스트)
-          </AntdWithStyleButton> */}
-          <AntdWithStyleButton onPress={() => navigation.navigate(mainNavigations.TRANSACTIONHISTORY_CREATE, { clubId: club.clubId, eventId: 'hi' })}>
+          </AntdWithStyleButton>
+          <AntdWithStyleButton onPress={() => navigation.navigate(mainNavigations.TRANSACTIONHISTORY_CREATE, { clubId: club.clubId, eventId: 'dbe9803f-b0cc-4f68-8176-d035d9032fc9' })}>
             거래내역 생성
           </AntdWithStyleButton>
         </View>

--- a/src/screens/event/EventCreateScreen.tsx
+++ b/src/screens/event/EventCreateScreen.tsx
@@ -1,16 +1,16 @@
-import { Button, Checkbox, DatePicker, Form, Input, Provider, View } from '@ant-design/react-native';
+import { Checkbox, DatePicker, Form, Input, Provider, View } from '@ant-design/react-native';
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import AntDesign from 'react-native-vector-icons/AntDesign';
+import AntdWithStyleButton from '../../components/AntdWithStyleButton';
 import CustomLoader from '../../components/Loader';
 import { mainNavigations } from '../../constants/navigations';
 import { useMutateCreateEvent } from '../../hooks/useEvent';
 import { useGetMemberList } from '../../hooks/useMember';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 import { EventCreateReq, GatherFeeInfo } from '../../types/event/request/EventCreateReq';
-import AntdWithStyleButton from '../../components/AntdWithStyleButton';
 
 
 type EventCreateScreenProps = StackScreenProps<

--- a/src/screens/transactionHistory/TransactionHistoryCreateScreen.tsx
+++ b/src/screens/transactionHistory/TransactionHistoryCreateScreen.tsx
@@ -11,7 +11,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import TransactionHistoryDepositCreate from '../../components/TransactionHistoryDepositCreate';
 import TransactionHistoryWithdrawCreate from '../../components/TransactionHistoryWithdrawCreate';
 import { mainNavigations } from '../../constants/navigations';
-import { useGetMemberList } from '../../hooks/useMember';
+import { useGetEventMemberList } from '../../hooks/useEventMember';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 
 type TransactionHistoryCreateScreenProps = StackScreenProps<
@@ -22,11 +22,15 @@ type TransactionHistoryCreateScreenProps = StackScreenProps<
 const TransactionHistoryCreateScreen = ({ route, navigation }: TransactionHistoryCreateScreenProps) => {
   const [isDepositView, setIsDepositView] = useState(true);
   const { clubId, eventId } = route.params;
-  const { data: memberGetListRes, isLoading, isError } = useGetMemberList(clubId);
+  const { data: eventMemberGetListRes, isLoading, isError } = useGetEventMemberList(eventId);
 
   const handleDepositViewToggle = () => {
     setIsDepositView(!isDepositView);
   };
+
+  const navigateGoBack = () => {
+    navigation.goBack();
+  }
 
   return (
     <SafeAreaView style={styles.container}>
@@ -53,12 +57,14 @@ const TransactionHistoryCreateScreen = ({ route, navigation }: TransactionHistor
           <TransactionHistoryDepositCreate 
             clubId={clubId}
             eventId={eventId}
-            memberGetListRes={memberGetListRes}
+            eventMemberGetListRes={eventMemberGetListRes}
+            navigateGoBack={navigateGoBack}
           />
           ) : (
           <TransactionHistoryWithdrawCreate
             clubId={clubId}
             eventId={eventId}
+            navigateGoBack={navigateGoBack}
           />    
           )}
       </ScrollView>

--- a/src/screens/webview/WebViewScreen.tsx
+++ b/src/screens/webview/WebViewScreen.tsx
@@ -86,7 +86,7 @@ function WebViewScreen({ route, navigation }: WebViewScreenProps) {
     <SafeAreaView style={styles.container}>
       <WebView
         ref={webViewRef}
-        source={{ uri: `https://movis.klr.kr/clubs/${clubId}` }}
+        source={{ uri: `https://movis.klr.kr/clubs/${clubId}/app` }}
         // source={{ uri: `http://10.0.2.2:3000/` }}
         onMessage={onMessage}
         onLoad={onLoad}

--- a/src/types/event/request/EventCreateReq.ts
+++ b/src/types/event/request/EventCreateReq.ts
@@ -11,4 +11,3 @@ type GatherFeeInfo = {
 }
   
 export type { EventCreateReq, GatherFeeInfo };
-  

--- a/src/types/eventBill/request/EventBillCreateReq.ts
+++ b/src/types/eventBill/request/EventBillCreateReq.ts
@@ -1,0 +1,9 @@
+type EventBillCreateReq = {
+    paidAmount: Number,
+    paidAt: String,
+    name: String,
+    explanation: String,
+    image: String,
+}
+  
+export type { EventBillCreateReq };

--- a/src/types/eventMember/response/EventMemberGetListRes.ts
+++ b/src/types/eventMember/response/EventMemberGetListRes.ts
@@ -1,0 +1,5 @@
+import { EventMemberGetRes } from "./EventMemberGetRes";
+
+type EventMemberGetListRes = EventMemberGetRes[];
+
+export type { EventMemberGetListRes };

--- a/src/types/eventMember/response/EventMemberGetRes.ts
+++ b/src/types/eventMember/response/EventMemberGetRes.ts
@@ -1,0 +1,7 @@
+type EventMemberGetRes = {
+	eventMemberId: string,
+	isPaid: boolean,
+	amountToPay: number
+}
+
+export type { EventMemberGetRes };

--- a/src/types/fee/request/FeeCreateReq.ts
+++ b/src/types/fee/request/FeeCreateReq.ts
@@ -1,0 +1,9 @@
+type FeeCreateReq = {
+    eventMemberId: String,
+    paidAmount: Number,
+    paidAt: String,
+    name: String,
+    explanation: String,
+}
+
+export type { FeeCreateReq };


### PR DESCRIPTION
## 이슈
- [내역 생성 스크린 api연결 #36](https://github.com/swm-backstage/movis-app/issues/36)

## 구현 기능
- eventMember
입금 내역 생성 시 필요한 eventMember를 조회하는 API연결 완료.
하지만, 백엔드 서버에서 전달받은 데이터에 eventMember의 "이름"과 "전화번호"가 포함되어 있지 않아서 추후 협업 필요
- fee, eventBill
입/출금 내역을 생성하는 API연결
초반 fee생성 시 계속 오류가 발생하였으나, 요청에 eventMember가 아닌 member의 id를 전달해서 발생하였음
- webView연결
React 웹 서버에서 아래와 같은 데이터를 함께 전달함과 동시에 React Native의 내역 생성 스크린이 표시됨
`{
"type": "transactionHistoryCreate",
"clubId": {clubId},
"eventId": {eventId}
}
`


## 작업 시간
2h