### PR TITLE
[feat] issue-#46: -붙이기, 이벤트멤버 이름 조회하기로 수정완료

### DIFF
--- a/src/api/eventBill.ts
+++ b/src/api/eventBill.ts
@@ -8,7 +8,7 @@ type EventBillCreateReqWithParams = {
   queryParams?: Record<string, any>;
 };
 
-const createEvenBill = async ({ body, queryParams }: EventBillCreateReqWithParams): Promise<void> => {
+const createEventBill = async ({ body, queryParams }: EventBillCreateReqWithParams): Promise<void> => {
   const config = {
     params: queryParams,
   };
@@ -22,5 +22,5 @@ const classifiedEventBill = async (eventBillId: string, body: EventBilClassified
     return data;
 };
 
-export { classifiedEventBill, createEvenBill };
+export { classifiedEventBill, createEventBill };
 

--- a/src/components/TransactionHistoryDepositCreate.tsx
+++ b/src/components/TransactionHistoryDepositCreate.tsx
@@ -25,12 +25,7 @@ const TransactionHistoryDepositCreate: React.FC<TransactionHistoryDepositCreateP
   navigateGoBack,
 }) => {
   const [form] = Form.useForm();
-  const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const createFee = useMutateCreateFee();
-
-  console.log(clubId, eventId);
-  console.log(eventMemberGetListRes);
 
   const onFinish = (data: any) => {
     const values: FeeCreateReq = {
@@ -81,7 +76,7 @@ const TransactionHistoryDepositCreate: React.FC<TransactionHistoryDepositCreateP
                 {eventMemberGetListRes
                   ? eventMemberGetListRes.eventMemberList.map((eventMember) => (
                       <Radio key={eventMember.eventMemberId} value={eventMember.eventMemberId} style={styles.checkbox}>
-                        {eventMember.eventMemberId}
+                        {eventMember.name}
                       </Radio>
                     ))
                   : undefined}

--- a/src/components/TransactionHistoryWithdrawCreate.tsx
+++ b/src/components/TransactionHistoryWithdrawCreate.tsx
@@ -26,7 +26,7 @@ const TransactionHistoryWithdrawCreate: React.FC<TransactionHistoryWithdrawCreat
   const onFinish = (data: any) => {
     const values: EventBillCreateReq = {
       image: form.getFieldValue("image"),
-      paidAmount: form.getFieldValue("paidAmount"),
+      paidAmount: -form.getFieldValue("paidAmount"),
       paidAt: form.getFieldValue("paidAt"),
       name: form.getFieldValue("name"),
       explanation: form.getFieldValue("explanation"),
@@ -34,7 +34,6 @@ const TransactionHistoryWithdrawCreate: React.FC<TransactionHistoryWithdrawCreat
     const queryParams = {
       eventId: eventId,
     }
-    console.log(values);
     createEventBill.mutate(
       { body: values, queryParams },
       {

--- a/src/hooks/useEventBill.ts
+++ b/src/hooks/useEventBill.ts
@@ -20,7 +20,7 @@ function useMutateCreateEventBill(
   mutationOptions?: UseMutationCustomOptions
 ) {
   return useMutation({
-    mutationFn: createEvenBill,
+    mutationFn: createEventBill,
     ...mutationOptions
   })
 }

--- a/src/screens/transactionHistory/TransactionHistoryCreateScreen.tsx
+++ b/src/screens/transactionHistory/TransactionHistoryCreateScreen.tsx
@@ -11,7 +11,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import TransactionHistoryDepositCreate from '../../components/TransactionHistoryDepositCreate';
 import TransactionHistoryWithdrawCreate from '../../components/TransactionHistoryWithdrawCreate';
 import { mainNavigations } from '../../constants/navigations';
-import { useGetEventMemberList } from '../../hooks/useEventMember';
+import { useQueryGetEventMemberList } from '../../hooks/useEventMember';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 
 type TransactionHistoryCreateScreenProps = StackScreenProps<
@@ -22,7 +22,7 @@ type TransactionHistoryCreateScreenProps = StackScreenProps<
 const TransactionHistoryCreateScreen = ({ route, navigation }: TransactionHistoryCreateScreenProps) => {
   const [isDepositView, setIsDepositView] = useState(true);
   const { clubId, eventId } = route.params;
-  const { data: eventMemberGetListRes, isLoading, isError } = useGetEventMemberList(eventId);
+  const { data: eventMemberGetListRes, isLoading, isError } = useQueryGetEventMemberList(eventId);
 
   const handleDepositViewToggle = () => {
     setIsDepositView(!isDepositView);

--- a/src/types/eventMember/response/EventMemberGetRes.ts
+++ b/src/types/eventMember/response/EventMemberGetRes.ts
@@ -1,5 +1,6 @@
 type EventMemberGetRes = {
 	eventMemberId: string,
+	name: string,
 	isPaid: boolean,
 	amountToPay: number
 }


### PR DESCRIPTION
# 이슈
- [거래 내역 생성 스크린 수정 #46](https://github.com/swm-backstage/movis-app/issues/46)

# 구현 기능
- 사용자로부터 금액 1,000원을 입력받았을 시, API통신 이전에 "-"를 붙이는 방식으로 구현
- eventMember조회시, eventMemberId 에서 name을 가져오도록 변경

# 작업 시간
10m
