### PR TITLE
[feat] issue-#47: 날짜 선택 모달 오류 해결

### DIFF
--- a/src/components/DateTimePickerWithAntDInput.tsx
+++ b/src/components/DateTimePickerWithAntDInput.tsx
@@ -1,15 +1,13 @@
-// HeaderTitle.tsx
-import { Input, View } from '@ant-design/react-native';
+import { Input, View, Icon } from '@ant-design/react-native';
 import React, { useState } from 'react';
-import { Text, StyleSheet } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 import DateTimePicker from 'react-native-modal-datetime-picker';
 
-type DateTImePickerWithAntdDInputProps = {
+type DateTimePickerWithAntdDInputProps = {
   setFormFieldsValue: (paidAt: string) => void;
 };
 
-const DateTimePickerWithAntdDInput: React.FC<DateTImePickerWithAntdDInputProps> = ({ setFormFieldsValue }) => {
+const DateTimePickerWithAntdDInput: React.FC<DateTimePickerWithAntdDInputProps> = ({ setFormFieldsValue }) => {
   const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
@@ -25,18 +23,22 @@ const DateTimePickerWithAntdDInput: React.FC<DateTImePickerWithAntdDInputProps> 
     const isoDateString = date.toISOString();
     setSelectedDate(isoDateString);
     setFormFieldsValue(isoDateString);
+    hideDatePicker();
   };
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity onPress={showDatePicker} style={styles.inputWrapper}>
-        <Input
-          value={selectedDate ? new Date(selectedDate).toLocaleString('ko-KR') : ''}
-          placeholder="날짜를 선택하세요"
-          style={styles.input}
-          editable={false}
-        />
-      </TouchableOpacity>
+      <Input
+        value={selectedDate ? new Date(selectedDate).toLocaleString('ko-KR') : ''}
+        placeholder="날짜를 선택하세요"
+        style={styles.input}
+        editable={false}
+        suffix={
+          <TouchableOpacity onPress={showDatePicker} style={styles.iconButton}>
+            <Icon name="calendar" style={styles.calendarIcon} />
+          </TouchableOpacity>
+        }
+      />
       <DateTimePicker
         isVisible={isDatePickerVisible}
         mode="datetime"
@@ -46,17 +48,13 @@ const DateTimePickerWithAntdDInput: React.FC<DateTImePickerWithAntdDInputProps> 
         maximumDate={new Date()}
         locale="ko-KR"
       />
-    </View>  
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-  },
-  inputWrapper: {
-    justifyContent: 'center',
-    height: '100%',
   },
   input: {
     paddingHorizontal: 10,
@@ -65,6 +63,13 @@ const styles = StyleSheet.create({
     borderColor: '#d9d9d9',
     borderWidth: 1,
     color: 'black',
+  },
+  iconButton: {
+    padding: 5,
+  },
+  calendarIcon: {
+    fontSize: 24,
+    color: '#5F47F1',
   },
 });
 


### PR DESCRIPTION
# 이슈
- [거래 내역 생성 스크린 달력 수정 #47](https://github.com/swm-backstage/movis-app/issues/47)

# 구현 기능
- 달력 선택 모달인 DateTimePickerWithAntdDInput에서 Input UI에서 선택 영역이 좁아지는 문제가 발생했다.
Input의 editable, pointerEvents의 값을 수정하면서 해결하려고 했지만 실패했다. 따라서 인풋 안에 새로운 버튼을 만드는 방식으로 해결했다. 인풋 안의 새로운 버튼은 antd Input의 suffix라는 속성을 추가하는 방식으로 구현했다.

# 이미지
![스크린샷 2024-10-16 오후 11 18 23](https://github.com/user-attachments/assets/5235e24d-e90d-468c-b2f1-de733ca574aa)

# 작업 시간
1h
