### PR TITLE
[fix] issue-#50: 스택 reset코드 제거

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -67,11 +67,6 @@ function useLogout(mutationOptions?: UseMutationCustomOptions){
         onSuccess:()=>{
             removeHeader('Authorization');
             removeEncryptStorage('refreshToken');
-            
-            navigation.reset({
-                index: 0,
-                routes: [{ name: 'Login' }],
-            });
         },
         onSettled:()=>{
             queryClient.invalidateQueries({queryKey:['auth']})


### PR DESCRIPTION
# 이슈
- [로그아웃 시 발생하는 에러 해결 #50](https://github.com/swm-backstage/movis-app/issues/50)

# 구현 기능
- 로그아웃 시 useLogout에서 다음과 같이 스택을 초기화 하였다.
```javascript
navigation.reset({
    index: 0,
    routes: [{ name: 'Login' }],
});
```
<img width="810" alt="스크린샷 2024-10-17 오후 3 14 18" src="https://github.com/user-attachments/assets/40aac0d6-966b-4f15-a58c-049fc630eeb7">
하지만,  RootStackNavigator에는 아래와 같이 구현되어 있고, 로그아웃 호출은 MainStackNavigator에서 진행하기 때문에 AuthStackNavigator에 존재하는 'Login'스크린을 찾을 수 없어서 에러가 발생하는 것으로 파악된다.

```javascript
{isLogin ? <MainStackNavigator /> : <AuthStackNavigator />}
```
당장 해결할 방법이 떠오르지 않기 때문에 임시 방편으로 reset코드를 지웠다. 또한 로그아웃 시점이 현재로서는 0번째 index의 스택이기 때문에, 스택이 쌓이는 문제는 없을 것으로 판단된다.

# 작업 시간
2h
