### PR TITLE
[feat] issue-#52: ButtomSheet 적용

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,15 +3,22 @@ import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import queryClient from './src/api/queryClient';
 import RootNavigator from './src/navigations/RootNavigator';
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 function App(): React.JSX.Element {
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <NavigationContainer>
-        <RootNavigator />
-      </NavigationContainer>
-    </QueryClientProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>
+        <QueryClientProvider client={queryClient}>
+          <NavigationContainer>
+            <RootNavigator />
+          </NavigationContainer>
+        </QueryClientProvider>
+      </BottomSheetModalProvider>
+    </GestureHandlerRootView>
+
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ant-design/icons-react-native": "^2.3.2",
     "@ant-design/react-native": "^5.1.3",
+    "@gorhom/bottom-sheet": "^5",
     "@react-native-async-storage/async-storage": "^1.24.0",
     "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-community/segmented-control": "^2.2.2",

--- a/src/hooks/useCustomButtomSheet.tsx
+++ b/src/hooks/useCustomButtomSheet.tsx
@@ -1,0 +1,86 @@
+// useCustomBottomSheet.tsx
+import React, { useRef, useCallback, useEffect, useState, ReactNode, useMemo } from 'react';
+import { StyleSheet, ViewStyle } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetBackdropProps,
+  BottomSheetBackdrop,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
+
+interface UseCustomBottomSheetProps {
+  snapPoints?: (string | number)[];
+  contentContainerStyle?: ViewStyle;
+}
+
+const useCustomBottomSheet = ({
+  snapPoints = useMemo(() => ['50%'], []),
+  contentContainerStyle,
+}: UseCustomBottomSheetProps) => {
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const openCustomBottomSheet = useCallback(() => {
+    setIsVisible(true);
+  }, []);
+
+  const closeCustomBottomSheet = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const handleSheetChanges = useCallback(
+    (index: number) => {
+      if (index === -1) {
+        setIsVisible(false);
+      }
+    },
+    []
+  );
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
+  useEffect(() => {
+    if (isVisible) {
+      bottomSheetModalRef.current?.present();
+    } else {
+      bottomSheetModalRef.current?.dismiss();
+    }
+  }, [isVisible]);
+
+  const CustomBottomSheet: React.FC<{ children: ReactNode }> = ({ children }) => (
+    <BottomSheetModal
+      ref={bottomSheetModalRef}
+      index={0}
+      snapPoints={snapPoints}
+      onChange={handleSheetChanges}
+      overDragResistanceFactor={2.5}
+      backdropComponent={renderBackdrop}
+      backgroundStyle={styles.background}
+      onDismiss={closeCustomBottomSheet}
+    >
+      <BottomSheetView style={contentContainerStyle}>
+        {children}
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+
+  return { openCustomBottomSheet, CustomBottomSheet };
+};
+
+const styles = StyleSheet.create({
+  background: {
+    backgroundColor: 'white',
+  },
+});
+
+export default useCustomBottomSheet;

--- a/src/screens/club/ClubListScreen.tsx
+++ b/src/screens/club/ClubListScreen.tsx
@@ -1,19 +1,19 @@
-import { Button, Icon } from '@ant-design/react-native';
+import { Icon } from '@ant-design/react-native';
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { RefreshControl, ScrollView } from 'react-native-gesture-handler';
 import AntDesign from 'react-native-vector-icons/AntDesign';
+import queryClient from '../../api/queryClient';
+import AntdWithStyleButton from '../../components/AntdWithStyleButton';
 import CustomLoader from '../../components/Loader';
+import { queryKeys } from '../../constants/key';
 import { mainNavigations } from '../../constants/navigations';
 import useAuth from '../../hooks/useAuth';
 import { useGetClubList } from '../../hooks/useClub';
+import useCustomBottomSheet from '../../hooks/useCustomButtomSheet';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 import { ClubGetRes } from '../../types/club/response/ClubGetRes';
-import AntdWithStyleButton from '../../components/AntdWithStyleButton';
-import queryClient from '../../api/queryClient';
-import { queryKeys } from '../../constants/key';
-
 
 type ClubHomeScreenProps = StackScreenProps<
   MainStackParamList,
@@ -24,8 +24,7 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
   const { data: data, isLoading, isError } = useGetClubList();
   const { logoutMutation } = useAuth();
   const [isRefreshing, setIsRefreshing] = useState(false);
-
-
+  
   const handlePressClubDetailScreen = (club: ClubGetRes) => {
     navigation.navigate(mainNavigations.CLUB_DETAIL, { club });
   };
@@ -48,7 +47,6 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
     );
   };
 
-
   const handleRefresh = async () => {
     try {
       setIsRefreshing(true);
@@ -66,15 +64,13 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
     return <CustomLoader />
   }
 
+
   return (
     <View style={styles.container}>
       <View style={styles.headerContainer}>
-        {/* <Text style={styles.userName}>
-          백진암
-        </Text> */}
         <Icon
           name="alert"
-          style={styles.alerIcon}
+          style={styles.alertIcon}
           onPress={() => {
             navigation.navigate(mainNavigations.NOTIFICATION);
           }}
@@ -82,21 +78,23 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
         <AntDesign
           name="logout"
           style={styles.logoutIcon}
-          onPress={() => {
-            showLogoutAlert();
-          }}
+          onPress={showLogoutAlert}
         />
       </View>
-      <ScrollView 
+
+      <ScrollView
         style={styles.clubListContainer}
         refreshControl={
-          <RefreshControl 
-            refreshing={isRefreshing} 
+          <RefreshControl
+            refreshing={isRefreshing}
             onRefresh={handleRefresh}
           />}
       >
         {data ? data.clubGetListDto.map((club: ClubGetRes) => (
-          <TouchableOpacity key={club.clubId} onPress={() => navigation.navigate(mainNavigations.WEBVIEW, { clubId: club.clubId })}>
+          <TouchableOpacity
+            key={club.clubId}
+            onPress={() => navigation.navigate(mainNavigations.WEBVIEW, { clubId: club.clubId })}
+          >
             <View style={styles.clubContainer}>
               <View style={styles.clubSettingContainer}>
                 <View style={styles.iconView}>
@@ -146,13 +144,20 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
         </AntdWithStyleButton>
       </View>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     width: '100%',
+  },
+  contentContainer: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  bottomSheetBackground: {
+    backgroundColor: 'white',
   },
   headerContainer: {
     paddingVertical: 8,
@@ -162,21 +167,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5, // Android용 그림자
     backgroundColor: 'white',
+    elevation: 5,
   },
-  userName: {
-    fontSize: 18,
-    color: 'black',
-  },
-  alerIcon:{
+  alertIcon: {
     fontSize: 30,
     color: 'rgba(153, 102, 255, 1)',
   },


### PR DESCRIPTION
# 이슈
- [BottomSheet 라이브러리 적용 #52](https://github.com/swm-backstage/movis-app/issues/52)

# 구현 기능
해당 기능이 필요하다는 것을 인지한 초반에는 직접 구현하려고 했지만, 자료 조사 후에 아래와 같이 잘 구현된 라이브러리가 있다는 것을 알게되어서 해당 라이브러리를 사용하기로 결정했다.
```code
yarn add @gorhom/bottom-sheet@^5
```
## 문제 상황
우선 ButtomSheet컴포넌트를 필요로하는 모든 스크린에 아래와 같은 중복된 코드를 필요로 한다. 심지어 아래 코드는 공식문서에 명시된 기본 기능이기 때문에 실제 프러덕트에서는 더 많은 중복 코드가 발생하게 된다.
```typescript
// ref
const bottomSheetRef = useRef<BottomSheet>(null);
// callbacks
const handleSheetChanges = useCallback((index: number) => {
  console.log('handleSheetChanges', index);
}, []);
```
### 컴포넌트 분리
따라서 커스텀 컴포넌트로 분리하여 코드 중복을 간소화하려고 시도했다.
하지만, 컴포넌트로 분리하더라도 해당 컴포넌트를 사용하는 스크린에서 모달을 나타나게 하는 함수가 중복되게 되었다. 
```typescript
const bottomSheetModalRef = useRef<BottomSheetModal>(null);
const snapPoints = ['70%'];

const openBottomSheet = useCallback(() => {
  bottomSheetModalRef.current?.present();
}, []);

const closeBottomSheet = useCallback(() => {
  bottomSheetModalRef.current?.dismiss();
}, []);

const handleSheetChanges = useCallback((index: number) => {
  // 필요한 경우 인덱스에 따라 로직 처리
}, []);
```
### 커스텀 훅
이러한 중복도 제거하기 위해 커스텀 훅을 구현하게 되었다.
커스텀 훅을 통해 아래와 같이 간결한 코드로 BottomSheet를 적용할 수 있게 되었다.
```typescript
const { openCustomBottomSheet, CustomBottomSheet } = useCustomBottomSheet({
  snapPoints: useMemo(() => ['80%'], []),
});

...

<CustomBottomSheet>
  {/* 모달에 표시할 내용 */}
  <View>
    <Text>모달 내용</Text>
  </View>
</CustomBottomSheet>
```

![Screenshot_1729231253](https://github.com/user-attachments/assets/3addf150-f95f-4ff5-aa8b-5199a8b003b7)

# 작업 시간
3h
