### PR TITLE
[feat] issue-#55: 옵션 UI구현 완료

### DIFF
--- a/src/components/SettingEntry.tsx
+++ b/src/components/SettingEntry.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { Alert, Image, StyleSheet, Text, View } from 'react-native';
+import SettingList from './SettingList';
+import SettingListItem from './SettingListItem';
+
+type SettingEntryProps = {
+    logout: () => void;
+};
+
+const SettingEntry: React.FC<SettingEntryProps> = ({ logout }) => {
+    const [isNotificationSet, setIsNotificationSet] = useState(false);
+
+    const handleNotificationPress = () => {
+        setIsNotificationSet(true);
+        Alert.alert("알림 설정이 완료되었습니다.");
+    };
+
+    const showLogoutAlert = () => {
+        Alert.alert(
+          "로그아웃",
+          "로그아웃 하시겠습니까?",
+          [
+            {
+              text: "아니오",
+              style: "cancel"
+            },
+            {
+              text: "예",
+              onPress: () => logout()
+            }
+          ],
+          { cancelable: false }
+        );
+    };
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.profileContainer}>
+                <Image
+                    source={{ uri: 'https://via.placeholder.com/50' }}
+                    style={styles.profileImage}
+                />
+                <Text style={styles.profileName}>백진암(Mock)</Text>
+            </View>
+
+            <SettingList title="권한 설정">
+                <SettingListItem 
+                    text="알림(개발중)" 
+                    onPress={handleNotificationPress} 
+                    disabled={isNotificationSet}
+                />
+            </SettingList>
+
+            <SettingList title="로그인 정보">
+                <SettingListItem 
+                    text="비밀번호 변경(추가 예정)" 
+                    onPress={() => Alert.alert("추가 예정입니다.")} 
+                    disabled={true}
+                />
+                <SettingListItem 
+                    text="로그아웃" 
+                    onPress={showLogoutAlert} 
+                />
+                <SettingListItem 
+                    text="회원 탈퇴(추가 예정)" 
+                    onPress={() => Alert.alert("추가 예정입니다.")} 
+                    disabled={true}
+                />
+            </SettingList>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 20,
+        backgroundColor: 'white',
+    },
+    profileContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 20,
+    },
+    profileImage: {
+        width: 50,
+        height: 50,
+        borderRadius: 25,
+        marginRight: 15,
+    },
+    profileName: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        color: '#333',
+    },
+});
+
+export default SettingEntry;

--- a/src/components/SettingList.tsx
+++ b/src/components/SettingList.tsx
@@ -1,0 +1,30 @@
+import React, { ReactNode } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type SettingListProps = {
+    title: string;
+    children: ReactNode; 
+};
+
+const SettingList: React.FC<SettingListProps> = ({ title, children }) => {
+    return (
+        <View style={styles.container}>
+            <Text style={styles.title}>{title}</Text>
+            {children}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        marginBottom: 20,
+    },
+    title: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        marginVertical: 10,
+        color: '#444',
+    },
+});
+
+export default SettingList;

--- a/src/components/SettingListItem.tsx
+++ b/src/components/SettingListItem.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
+
+type SettingListItemProps = {
+    text: string;
+    onPress: () => void;
+    disabled?: boolean; // 비활성화 상태를 나타내는 prop 추가
+};
+
+const SettingListItem: React.FC<SettingListItemProps> = ({ text, onPress, disabled }) => {
+    return (
+        <TouchableOpacity 
+            style={styles.container} 
+            onPress={onPress}
+            disabled={disabled}
+        >
+            <Text style={[styles.text, disabled && styles.disabledText]}>{text}</Text>
+        </TouchableOpacity>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 15,
+        borderBottomWidth: 1,
+        borderBottomColor: '#ddd',
+    },
+    text: {
+        fontSize: 16,
+        marginLeft: 15,
+        color: '#000',
+    },
+    disabledText: {
+        color: '#aaa', // 글자색을 회색으로 변경
+    },
+});
+
+export default SettingListItem;

--- a/src/hooks/useCustomButtomSheet.tsx
+++ b/src/hooks/useCustomButtomSheet.tsx
@@ -14,7 +14,7 @@ interface UseCustomBottomSheetProps {
 }
 
 const useCustomBottomSheet = ({
-  snapPoints = useMemo(() => ['50%'], []),
+  snapPoints,
   contentContainerStyle,
 }: UseCustomBottomSheetProps) => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
@@ -74,7 +74,7 @@ const useCustomBottomSheet = ({
     </BottomSheetModal>
   );
 
-  return { openCustomBottomSheet, CustomBottomSheet };
+  return { openCustomBottomSheet, closeCustomBottomSheet, CustomBottomSheet };
 };
 
 const styles = StyleSheet.create({

--- a/src/screens/club/ClubListScreen.tsx
+++ b/src/screens/club/ClubListScreen.tsx
@@ -1,12 +1,12 @@
-import { Icon } from '@ant-design/react-native';
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useMemo, useState } from 'react';
-import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { RefreshControl, ScrollView } from 'react-native-gesture-handler';
 import AntDesign from 'react-native-vector-icons/AntDesign';
 import queryClient from '../../api/queryClient';
 import AntdWithStyleButton from '../../components/AntdWithStyleButton';
 import CustomLoader from '../../components/Loader';
+import SettingEntry from '../../components/SettingEntry';
 import { queryKeys } from '../../constants/key';
 import { mainNavigations } from '../../constants/navigations';
 import useAuth from '../../hooks/useAuth';
@@ -22,29 +22,14 @@ type ClubHomeScreenProps = StackScreenProps<
 
 function ClubListScreen({ navigation }: ClubHomeScreenProps) {
   const { data: data, isLoading, isError } = useGetClubList();
-  const { logoutMutation } = useAuth();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { logoutMutation } = useAuth();
+  const { openCustomBottomSheet, closeCustomBottomSheet, CustomBottomSheet } = useCustomBottomSheet({
+    snapPoints: useMemo(() => ['80%'], []),
+  });
   
   const handlePressClubDetailScreen = (club: ClubGetRes) => {
     navigation.navigate(mainNavigations.CLUB_DETAIL, { club });
-  };
-
-  const showLogoutAlert = () => {
-    Alert.alert(
-      "로그아웃",
-      "로그아웃 하시겠습니까?",
-      [
-        {
-          text: "아니오",
-          style: "cancel"
-        },
-        {
-          text: "예",
-          onPress: () => logoutMutation.mutate()
-        }
-      ],
-      { cancelable: false }
-    );
   };
 
   const handleRefresh = async () => {
@@ -60,25 +45,23 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
     }
   };
 
+  
   if (isLoading) {
     return <CustomLoader />
   }
-
-
   return (
     <View style={styles.container}>
-      <View style={styles.headerContainer}>
-        <Icon
-          name="alert"
-          style={styles.alertIcon}
-          onPress={() => {
-            navigation.navigate(mainNavigations.NOTIFICATION);
-          }}
+      <CustomBottomSheet>
+        <SettingEntry 
+          logout={() => (logoutMutation.mutate())}
         />
+      </CustomBottomSheet>
+
+      <View style={styles.headerContainer}>
         <AntDesign
-          name="logout"
-          style={styles.logoutIcon}
-          onPress={showLogoutAlert}
+          name="setting"
+          onPress={openCustomBottomSheet}
+          style={styles.settingIcon}
         />
       </View>
 


### PR DESCRIPTION
# 이슈
- [BottomSheet를 이용한 Setting화면 구현 #55
](https://github.com/swm-backstage/movis-app/issues/55)

# 구현 기능
- SettingEntry.tsx
BottomSheet의 Child로 해당 SettingEntry를 넘겨줍니다.
사용자 정보 조회 UI, 사용자 디바이스 알림 권한 설정, 비밀번호 변경(백엔드 개발 진행중), 로그아웃, 회원탈퇴(백엔드 개발 진행중)
- SettingList.tsx, SettingListItem.tsx
SettingEntry에서 각종 설정 리스트 버튼을 컴포넌트화를 진행하였습니다.
# UI
![Screenshot_1729408163](https://github.com/user-attachments/assets/65fe40e5-5f92-469c-b20b-0fc858ad65c2)


# 작업 시간
1h 30m
