### PR TITLE
[fix] feature/issue-#67: react query관련 캐시  해결

### DIFF
--- a/src/components/ClubList.tsx
+++ b/src/components/ClubList.tsx
@@ -20,7 +20,8 @@ type SettingEntryProps = {
 
 const ClubList: React.FC<SettingEntryProps> = ({ handlePressClubCreateScreen, handlePressClubDetailScreen, handlePressWebView }) => {
 	const [isRefreshing, setIsRefreshing] = useState(false);
-	const { data: clubListData, isLoading: clubListIsLoading } = useGetClubList();
+	const { data: clubListData, isLoading: clubListIsLoading, isSuccess, isError } = useGetClubList();
+	console.log(isSuccess, isError, clubListIsLoading)
 	// MockData
 	const images = [
 		require('../assets/welcom.png'),

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import {  useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { getAccessToken, logout, postLogin, postSingup } from "../api/auth";
 import { UseMutationCustomOptions, UseQueryCustomOptions } from "../types/common";
 import { removeEncryptStorage, setEncryptStorage } from "../utils/encryptStorage";
@@ -6,6 +6,7 @@ import { removeHeader, setHeader } from "../utils/header";
 import { useEffect } from "react";
 import queryClient from '../api/queryClient';
 import { useNavigation } from "@react-navigation/native";
+import { queryKeys } from "../constants/key";
 
 
 
@@ -16,73 +17,73 @@ function useSignup(mutationOptions?: UseMutationCustomOptions) {
     });
 }
 
-function useLogin(mutationOptions?: UseMutationCustomOptions){
+function useLogin(mutationOptions?: UseMutationCustomOptions) {
     return useMutation({
         mutationFn: postLogin,
-        onSuccess:({accessToken, refreshToken})=>{
+        onSuccess: ({ accessToken, refreshToken }) => {
             setEncryptStorage('refreshToken', refreshToken);
             setHeader('Authorization', `Bearer ${accessToken}`)
         },
-        onError:(error)=>{
+        onError: (error) => {
             console.log("Login Failed", error.response?.data);
         },
-        onSettled: ()=>{
-            queryClient.refetchQueries({queryKey:['auth','getAccessToken']})
+        onSettled: () => {
+            queryClient.refetchQueries({ queryKey: ['auth', 'getAccessToken'] })
         },
         ...mutationOptions,
     })
 }
 
 
-function useGetRefreshToken(){
-    const {data, isSuccess, isError} = useQuery({
-        queryKey: ['auth','getAccessToken'],
+function useGetRefreshToken() {
+    const { data, isSuccess, isError, isLoading } = useQuery({
+        queryKey: ['auth', 'getAccessToken'],
         queryFn: getAccessToken,
-        staleTime: 1000*60*28,
-        refetchInterval: 1000*60*28,
+        staleTime: 1000 * 60 * 28,
+        refetchInterval: 1000 * 60 * 28,
         refetchOnReconnect: true,
         refetchIntervalInBackground: true, // 앱이 백그라운드일 때도 다시 가져옴
     })
 
-    useEffect(()=>{
-        if(isSuccess){
+    useEffect(() => {
+        if (isSuccess) {
             setHeader('Authorization', `Bearer ${data.accessToken}`),
-            setEncryptStorage('refresthToken', data.refreshToken)
+                setEncryptStorage('refresthToken', data.refreshToken)
         }
     }, [isSuccess]);
-    useEffect(()=>{
-        if(isError){
+    useEffect(() => {
+        if (isError) {
+
             removeHeader('Authorization'),
-            removeEncryptStorage('refreshToken')
+                removeEncryptStorage('refreshToken')
         }
     }, [isError]);
-    return {isSuccess, isError};
+    return { isSuccess, isError };
 }
 
-function useLogout(mutationOptions?: UseMutationCustomOptions){
+function useLogout(mutationOptions?: UseMutationCustomOptions) {
     const navigation = useNavigation();
 
     return useMutation({
         mutationFn: logout,
-        onSuccess:()=>{
+        onSuccess: () => {
             removeHeader('Authorization');
             removeEncryptStorage('refreshToken');
         },
-        onSettled:()=>{
-            queryClient.invalidateQueries({queryKey:['auth']})
+        onSettled: () => {
+            queryClient.invalidateQueries();
         },
         ...mutationOptions
     });
 }
 
-function useAuth(){
+function useAuth() {
     const signupMutation = useSignup();
     const refreshTokenQuery = useGetRefreshToken();
     const isLogin = refreshTokenQuery.isSuccess;
     const loginMutation = useLogin();
     const logoutMutation = useLogout();
-
-    return {signupMutation, loginMutation, isLogin,logoutMutation};
+    return { signupMutation, loginMutation, isLogin, logoutMutation };
 }
 
 export default useAuth;

--- a/src/hooks/useClub.ts
+++ b/src/hooks/useClub.ts
@@ -12,13 +12,15 @@ function useGetClub(
   return useQuery({
     queryFn: () => getClub(clubId),
     queryKey: [queryKeys.CLUB, queryKeys.GET_CLUB, clubId]
+
   })
 }
 
 function useGetClubList() {
   return useQuery({
     queryFn: () => getClubList(),
-    queryKey: [queryKeys.CLUB, queryKeys.GET_CLUBLIST]
+    queryKey: [queryKeys.CLUB, queryKeys.GET_CLUBLIST],
+
   })
 }
 

--- a/src/navigations/RootNavigator.tsx
+++ b/src/navigations/RootNavigator.tsx
@@ -9,12 +9,12 @@ import Toast from 'react-native-toast-message';
 
 
 function RootNavigator() {
+  console.log('RootNavigator Screen');
   const { isLogin } = useAuth();
   const [modalVisible, setModalVisible] = useState(false);
   const [depositCount, setDepositCount] = useState(0);
   const [withdrawCount, setWithdrawCount] = useState(0);
 
-  console.log('isLogin:', isLogin);
 
   useEffect(() => {
     if (!isLogin) return;
@@ -37,7 +37,7 @@ function RootNavigator() {
         // 앱이 백그라운드로 전환될 때 AsyncStorage 값을 0으로 초기화
         await AsyncStorage.setItem('@depositCount', '0');
         await AsyncStorage.setItem('@withdrawCount', '0');
-    }
+      }
     };
 
     const subscription = AppState.addEventListener('change', handleAppStateChange);

--- a/src/screens/club/ClubDetailScreen.tsx
+++ b/src/screens/club/ClubDetailScreen.tsx
@@ -65,9 +65,9 @@ const ClubDetailScreen = ({ route, navigation }: ClubDetailScreenProps) => {
       duration: 0,
       easing: Easing.inOut(Easing.ease),
     });
-  
+
     createClubUser.mutate(
-      {'clubId': club.clubId, 'identifier': values.identifier},
+      { 'clubId': club.clubId, 'identifier': values.identifier },
       {
         onError: (error) => {
           console.error(error, error.response?.data);
@@ -144,7 +144,7 @@ const ClubDetailScreen = ({ route, navigation }: ClubDetailScreenProps) => {
             </AntdWithStyleButton>
           </Animated.View>
           <View>
-            <ClubUserScrollView clubId={club.clubId}/>
+            <ClubUserScrollView clubId={club.clubId} />
           </View>
           <AntdWithStyleButton onPress={() => navigation.navigate(mainNavigations.CLUB_USER_UPDATE, { clubId: club.clubId })}>
             운영진 수정

--- a/src/screens/club/ClubListScreen.tsx
+++ b/src/screens/club/ClubListScreen.tsx
@@ -11,9 +11,11 @@ import useCustomBottomSheet from '../../hooks/useCustomButtomSheet';
 import { useGetUser } from '../../hooks/useUser';
 import { MainStackParamList } from '../../navigations/MainStackNavigator';
 import { ClubGetRes } from '../../types/club/response/ClubGetRes';
+import { AuthStackParamList } from '../../navigations/AuthStackNavigator';
 
 type ClubHomeScreenProps = StackScreenProps<
   MainStackParamList,
+
   typeof mainNavigations.CLUB_LIST
 >;
 
@@ -25,7 +27,7 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
   });
   const handlePressClubCreateScreen = () => {
     navigation.navigate(mainNavigations.CLUB_CREATE);
-  };  
+  };
   const handlePressClubDetailScreen = (club: ClubGetRes) => {
     navigation.navigate(mainNavigations.CLUB_DETAIL, { club });
   };
@@ -74,7 +76,7 @@ function ClubListScreen({ navigation }: ClubHomeScreenProps) {
       <CustomBottomSheet>
         <SettingEntry
           user={user}
-          logout={() => logoutMutation.mutate()}
+          logout={() => logoutMutation.mutate(undefined)}
         />
       </CustomBottomSheet>
     </View>

--- a/src/screens/unclassified/DepositClassifiedScreen.tsx
+++ b/src/screens/unclassified/DepositClassifiedScreen.tsx
@@ -39,7 +39,7 @@ function DepositClassifiedScreen({ route, navigation }: DepositClassifiedScreenP
                 [
                     {
                         text: '확인',
-                        onPress: () => navigation.navigate(mainNavigations.UNCLASSIFIED),
+                        onPress: () => navigation.navigate(mainNavigations.UNCLASSIFIED, { clubId }),
                     },
                 ]
             );
@@ -51,7 +51,7 @@ function DepositClassifiedScreen({ route, navigation }: DepositClassifiedScreenP
                 [
                     {
                         text: '확인',
-                        onPress: () => navigation.navigate(mainNavigations.UNCLASSIFIED),
+                        onPress: () => navigation.navigate(mainNavigations.UNCLASSIFIED, { clubId }),
                     },
                 ]
             );


### PR DESCRIPTION
# 이슈
- #67 

# 구현 배경

처음 로그인한 아이디에서 로그아웃하고 다른 아이디로 로그인 했을 때 메인화면에 이전 유저의 ClubList가 보여지는 상황이 발견되어 이를 해결하였다.

# 구현 내용

### 원인
문제의 원인은 react query의 캐시에 있었다. club list를 조회하는 쿼리에 stale과 관련된 옵션을 아무것도 주지 않아 일단 쿼리를 실행하고 쿼리키 상태는 stale이다. 하지만 캐시된 데이터는 기본적으로 메모리에 5분정도 남아있어 다음 로그인한 사용자에게 잠깐 보여지게 되는 것이었다.

### 해결
먼저 queryClient.clear()를 사용하여 해결해 보려 했는데 로그아웃을 진행하고 화면이 CLubListScreen에 고정되어버리는 문제가 발생하였다. 
여기서 queryClient.clear()는  useQuery를 이용해 값을 변화시키는 과정이 작동하지 않는다는 사실을 알게 되었다.

따라서 invalidateQueries()로 모든 쿼리키를 로그아웃시 onSettled 옵션으로 무효화 시키도록 구현하였다.
이렇게 되면 로그아웃시 RootNavigator내의 useAuth()에서 useQuery가 쿼리키 옵션 변화를 감지해 새로운 요청을 보내고 그에 따라 isLogin은 false가 될 수 있어 로그인페이지로 돌아올 수 있다.
